### PR TITLE
Detect Azure SQL Database

### DIFF
--- a/lib/bibliothecary/multi_parsers/ms_sql_server.rb
+++ b/lib/bibliothecary/multi_parsers/ms_sql_server.rb
@@ -1,7 +1,7 @@
 module Bibliothecary
   module MultiParsers
     module MsSqlServer
-      def identify_ms_sql_server_version(dsp)
+      def identify_database_version(dsp)
         version_number = dsp.match(/\d+/)&.[](0)
         return nil unless version_number
 
@@ -14,6 +14,16 @@ module Bibliothecary
 
         version_number += '.0' unless version_number.end_with?('.0')
         version_number
+      rescue
+        nil
+      end
+
+      def identify_database_name(dsp)
+        if dsp.downcase.include?('azure')
+          return 'Azure SQL Database'
+        else
+          return 'Microsoft SQL Server'
+        end
       rescue
         nil
       end

--- a/lib/bibliothecary/parsers/nuget.rb
+++ b/lib/bibliothecary/parsers/nuget.rb
@@ -147,12 +147,16 @@ module Bibliothecary
       def self.parse_sqlproj(file_contents, options: {})
         manifest = Ox.parse file_contents
         dsp = manifest.locate('Project/PropertyGroup/DSP')&.first&.text || manifest.locate('PropertyGroup/DSP')&.first&.text
-        version = identify_ms_sql_server_version(dsp) if dsp
+        return [] unless dsp
+        database = identify_database_name(dsp) 
+        version = identify_database_version(dsp)
         [{
-          name: "Microsoft SQL Server",
+          name: database,
           requirement: version,
           type: "development"
         }]
+      rescue
+        []
       end
 
       def self.parse_nuspec(file_contents, options: {})

--- a/lib/bibliothecary/parsers/nuget.rb
+++ b/lib/bibliothecary/parsers/nuget.rb
@@ -148,8 +148,11 @@ module Bibliothecary
         manifest = Ox.parse file_contents
         dsp = manifest.locate('Project/PropertyGroup/DSP')&.first&.text || manifest.locate('PropertyGroup/DSP')&.first&.text
         return [] unless dsp
+
         database = identify_database_name(dsp) 
         version = identify_database_version(dsp)
+        return [] if database.nil?
+        
         [{
           name: database,
           requirement: version,

--- a/lib/bibliothecary/version.rb
+++ b/lib/bibliothecary/version.rb
@@ -1,3 +1,3 @@
 module Bibliothecary
-  VERSION = "8.6.3"
+  VERSION = "1.1.0"
 end


### PR DESCRIPTION
[Trello card](https://trello.com/c/4yqe36zY/6693-while-using-azure-sql-as-db-stackshare-is-showing-as-microsoft-sql-server)

Now if there is a .sqlproj file it is marked as MS SQL Server, So even though if a project is using Azure DB, which uses same configuration file .sqlproj, that is also wrongly detected as MS SQL. 

In this PR, it is changed in such a way that looking at the contents(DSP tag) inside the .sqlproj file, it is detected as either Azure SQL database or MS SQL Server. Gem version is also changed from 8.6.5 in the code to 1.1.0. 8.6.5 was the version used by original bibliothecary gem.