### PR TITLE
Identify gems with custom pattern from Gemfile

### DIFF
--- a/lib/bibliothecary/multi_parsers/bundler_like_manifest.rb
+++ b/lib/bibliothecary/multi_parsers/bundler_like_manifest.rb
@@ -21,8 +21,7 @@ module Bibliothecary
       # Method to extract gems with a pattern from the Gemfile content
       def extract_gems_by_pattern(pattern, gemfile_content)
         gems = []
-        puts "Gemfile Content from gem"
-        puts gemfile_content
+        
         gemfile_content.scan(pattern) do |gem_name, _require_option|
           gems << { name: gem_name.strip, type: :runtime }
         end

--- a/lib/bibliothecary/multi_parsers/bundler_like_manifest.rb
+++ b/lib/bibliothecary/multi_parsers/bundler_like_manifest.rb
@@ -17,6 +17,18 @@ module Bibliothecary
           })
         end.uniq
       end
+
+      # Method to extract gems with a pattern from the Gemfile content
+      def extract_gems_by_pattern(pattern, gemfile_content)
+        gems = []
+        puts "Gemfile Content from gem"
+        puts gemfile_content
+        gemfile_content.scan(pattern) do |gem_name, _require_option|
+          gems << { name: gem_name.strip, type: :runtime }
+        end
+
+        gems
+      end
     end
   end
 end

--- a/lib/bibliothecary/parsers/rubygems.rb
+++ b/lib/bibliothecary/parsers/rubygems.rb
@@ -57,7 +57,7 @@ module Bibliothecary
         manifest = Gemnasium::Parser.send(:gemfile, file_contents)
 
         dependencies_found = parse_ruby_manifest(manifest)
-        # patten:gem 'redis', require: %w[redis redis/connection/hiredis]
+        # patten: gem 'redis', require: %w[redis redis/connection/hiredis]
         dependencies_found_with_new_pattern = extract_gems_by_pattern(
           /gem\s+['"]([^'"]+)['"],\s*require:\s*%w\[([^\]]+)\]/,
           file_contents

--- a/lib/bibliothecary/parsers/rubygems.rb
+++ b/lib/bibliothecary/parsers/rubygems.rb
@@ -55,7 +55,23 @@ module Bibliothecary
 
       def self.parse_gemfile(file_contents, options: {})
         manifest = Gemnasium::Parser.send(:gemfile, file_contents)
-        parse_ruby_manifest(manifest)
+
+        dependencies_found = parse_ruby_manifest(manifest)
+        dependencies_found_with_new_pattern = extract_gems_by_pattern(
+          /gem\s+['"]([^'"]+)['"],\s*require:\s*%w\[([^\]]+)\]/,
+          file_contents
+        )
+
+        return dependencies_found if dependencies_found_with_new_pattern.empty?
+        
+        puts "Gems identified by Bibliothecary"
+        puts dependencies_found.concat(dependencies_found_with_new_pattern)
+                          .group_by { |item| item[:name] }
+                          .values.map(&:first)
+        puts "=================================="
+        dependencies_found.concat(dependencies_found_with_new_pattern)
+                          .group_by { |item| item[:name] }
+                          .values.map(&:first)
       end
 
       def self.parse_gemspec(file_contents, options: {})

--- a/lib/bibliothecary/parsers/rubygems.rb
+++ b/lib/bibliothecary/parsers/rubygems.rb
@@ -57,6 +57,7 @@ module Bibliothecary
         manifest = Gemnasium::Parser.send(:gemfile, file_contents)
 
         dependencies_found = parse_ruby_manifest(manifest)
+        # patten:gem 'redis', require: %w[redis redis/connection/hiredis]
         dependencies_found_with_new_pattern = extract_gems_by_pattern(
           /gem\s+['"]([^'"]+)['"],\s*require:\s*%w\[([^\]]+)\]/,
           file_contents

--- a/lib/bibliothecary/parsers/rubygems.rb
+++ b/lib/bibliothecary/parsers/rubygems.rb
@@ -64,11 +64,6 @@ module Bibliothecary
 
         return dependencies_found if dependencies_found_with_new_pattern.empty?
         
-        puts "Gems identified by Bibliothecary"
-        puts dependencies_found.concat(dependencies_found_with_new_pattern)
-                          .group_by { |item| item[:name] }
-                          .values.map(&:first)
-        puts "=================================="
         dependencies_found.concat(dependencies_found_with_new_pattern)
                           .group_by { |item| item[:name] }
                           .values.map(&:first)

--- a/lib/bibliothecary/version.rb
+++ b/lib/bibliothecary/version.rb
@@ -1,3 +1,3 @@
 module Bibliothecary
-  VERSION = "1.1.0"
+  VERSION = "1.1.1"
 end

--- a/spec/fixtures/Gemfile
+++ b/spec/fixtures/Gemfile
@@ -3,6 +3,7 @@ ruby '2.2.1'
 
 gem 'oj'
 gem 'rails', '4.2.0'
+gem 'redis', require: %w[redis redis/connection/hiredis]
 gem 'leveldb-ruby','0.15', require: 'leveldb'
 
 group :development do

--- a/spec/multi_parsers/bundler_like_manifest_spec.rb
+++ b/spec/multi_parsers/bundler_like_manifest_spec.rb
@@ -5,9 +5,9 @@ describe Bibliothecary::MultiParsers::BundlerLikeManifest do
     let(:gemfile_content) do
       <<-GEMFILE
         gem 'oj'
-		    gem 'rails', '4.2.0'
-		    gem 'redis', require: %w[redis redis/connection/hiredis]
-		    gem 'leveldb-ruby','0.15', require: 'leveldb'
+		  gem 'rails', '4.2.0'
+		  gem 'redis', require: %w[redis redis/connection/hiredis]
+		  gem 'leveldb-ruby','0.15', require: 'leveldb'
       GEMFILE
     end
 

--- a/spec/multi_parsers/bundler_like_manifest_spec.rb
+++ b/spec/multi_parsers/bundler_like_manifest_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe Bibliothecary::MultiParsers::BundlerLikeManifest do
-	describe '#extract_gems_by_pattern' do
+  describe '#extract_gems_by_pattern' do
     let(:gemfile_content) do
       <<-GEMFILE
         gem 'oj'

--- a/spec/multi_parsers/bundler_like_manifest_spec.rb
+++ b/spec/multi_parsers/bundler_like_manifest_spec.rb
@@ -5,11 +5,14 @@ describe Bibliothecary::MultiParsers::BundlerLikeManifest do
     let(:gemfile_content) do
       <<-GEMFILE
         gem 'oj'
-		  gem 'rails', '4.2.0'
-		  gem 'redis', require: %w[redis redis/connection/hiredis]
-		  gem 'leveldb-ruby','0.15', require: 'leveldb'
+
+        gem 'rails', '4.2.0'
+        gem 'redis', require: %w[redis redis/connection/hiredis]
+
+        gem 'leveldb-ruby','0.15', require: 'leveldb'
       GEMFILE
     end
+
 
     context 'when the pattern matches gems with require option' do
       it 'extracts gems with the specified pattern' do

--- a/spec/multi_parsers/bundler_like_manifest_spec.rb
+++ b/spec/multi_parsers/bundler_like_manifest_spec.rb
@@ -1,0 +1,36 @@
+require 'spec_helper'
+
+describe Bibliothecary::MultiParsers::BundlerLikeManifest do
+	describe '#extract_gems_by_pattern' do
+    let(:gemfile_content) do
+      <<-GEMFILE
+        gem 'oj'
+		    gem 'rails', '4.2.0'
+		    gem 'redis', require: %w[redis redis/connection/hiredis]
+		    gem 'leveldb-ruby','0.15', require: 'leveldb'
+      GEMFILE
+    end
+
+    context 'when the pattern matches gems with require option' do
+      it 'extracts gems with the specified pattern' do
+        pattern = /gem\s+['"]([^'"]+)['"],\s*require:\s*%w\[([^\]]+)\]/
+
+        extracted_gems = Bibliothecary::Parsers::Rubygems.extract_gems_by_pattern(pattern, gemfile_content)
+
+        expect(extracted_gems).to contain_exactly(
+          { name: 'redis', type: :runtime }
+        )
+      end
+    end
+
+    context 'when the pattern does not match any gems' do
+      it 'returns an empty array' do
+        pattern = /invalid_pattern/
+
+        extracted_gems = Bibliothecary::Parsers::Rubygems.extract_gems_by_pattern(pattern, gemfile_content)
+
+        expect(extracted_gems).to be_empty
+      end
+    end
+ end
+end

--- a/spec/parsers/rubygems_spec.rb
+++ b/spec/parsers/rubygems_spec.rb
@@ -17,7 +17,8 @@ describe Bibliothecary::Parsers::Rubygems do
         { name: "thin", requirement: ">= 0", type: :development },
         { name: "puma", requirement: ">= 0", type: :runtime },
         { name: "rails_12factor", requirement: ">= 0", type: :runtime },
-        { name: "bugsnag", requirement: ">= 0", type: :runtime }
+        { name: "bugsnag", requirement: ">= 0", type: :runtime },
+        { name: "redis", type: :runtime }
       ],
       kind: 'manifest',
       success: true


### PR DESCRIPTION
[Trello card
](https://trello.com/c/c67UDlat/6781-incorrect-stack-alert-received-for-stackshare-backend-repo)
## Problem
Gems with pattern `gem ‘redis’, require: %w[redis redis/connection/hiredis]` is not detected by Bibliothecary.


## Solution
Analyze the Gemfile contents and identify gems with the new pattern using regex 


